### PR TITLE
add missing equal sign for edit-link class.

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -20,7 +20,7 @@
 					'after'  => '</div>',
 				) );
 			?>
-			<?php edit_post_link( __( 'Edit This', 'flounder' ), '<p class"edit-link">', '</p>' ); ?> 
+			<?php edit_post_link( __( 'Edit This', 'flounder' ), '<p class="edit-link">', '</p>' ); ?> 
 		</div><!-- .entry-content -->
 		
 		<?php


### PR DESCRIPTION
A small typo on line 23 is that there was no equal sign for the edit-link class.
